### PR TITLE
QA fixes

### DIFF
--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -160,13 +160,6 @@ export default class Toolbar extends Component {
 
     if (currentContentState === newContentState) {
       this.shouldUpdatePos = true;
-      this.setState({
-        show: true
-      });
-    } else {
-      this.setState({
-        show: false
-      });
     }
   }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -297,7 +297,10 @@ export default class Toolbar extends Component {
     );
   }
   render() {
-    if (this.props.readOnly) {
+    if (
+      this.props.readOnly &&
+      !this.props.shouldDisplayToolbarFn(this.props, this.state)
+    ) {
       return null;
     }
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -93,7 +93,7 @@ export default class Toolbar extends Component {
         const { entity = "LINK" } = item;
         key = "entity-" + entity;
         toggle = () => this.toggleEntity(entity);
-        active = this.hasEntity(entity);
+        active = this.hasEntity(entity) || this.hasStyle(item.style);
         break;
       }
     }
@@ -193,6 +193,12 @@ export default class Toolbar extends Component {
       return contentState.getEntity(entityKey);
     }
     return null;
+  }
+
+  hasStyle(style) {
+    const current = this.props.editorState.getCurrentInlineStyle();
+    const withStyle = current.filter((val, key) => key.startsWith(style));
+    return withStyle.size > 0;
   }
 
   hasEntity(entityType) {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -305,15 +305,17 @@ export default class Toolbar extends Component {
         className={toolbarClass}
         style={this.state.position}
         ref="toolbarWrapper"
-        onMouseDown={e => {
-          e.preventDefault();
-        }}
       >
         <div style={{ position: "absolute", bottom: 0 }}>
           <div
             className="toolbar__wrapper"
             ref={el => {
               this.toolbarEl = el;
+            }}
+            onMouseDown={e => {
+              if (e.target.localName !== "input") {
+                e.preventDefault();
+              }
             }}
           >
             {this.state.editingEntity

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -40,6 +40,7 @@ export default class ToolbarWrapper extends Component {
           entityInputs={this.props.entityInputs}
           onChange={this.onChange}
           editorHasFocus={true}
+          shouldDisplayToolbarFn={this.props.shouldDisplayToolbarFn}
         />
       </div>
     );
@@ -140,12 +141,26 @@ describe("Toolbar Component", () => {
       expect(items).toHaveLength(1);
     });
 
-    it("renders as null when readOnly is set", () => {
+    it("renders when readOnly is set but shouldDisplayToolbarFn returns true", () => {
       const wrapper = mount(
         <ToolbarWrapper
           readOnly
           editorState={testContext.editorState}
           actions={testContext.actions}
+          shouldDisplayToolbarFn={() => true}
+        />
+      );
+      const toolbar = wrapper.find(Toolbar);
+      expect(toolbar.html()).not.toBeNull();
+    });
+
+     it("renders as null when readOnly is set and shouldDisplayToolbarFn returns false", () => {
+      const wrapper = mount(
+        <ToolbarWrapper
+          readOnly
+          editorState={testContext.editorState}
+          actions={testContext.actions}
+          shouldDisplayToolbarFn={() => false}
         />
       );
       const toolbar = wrapper.find(Toolbar);


### PR DESCRIPTION
@buob @crossman 

https://trello.com/c/AxRgVugh/808-05-spike-editor-qa

remove `preventdefault` allows for selecting  text in entity inputs

`hasStyle` shows the active states for color and font buttons in the toolbar

`shouldDisplayToolabrFn` was from the adding the email editor ticket

remove setting sow to false in the lifecycle method is for allowing the color input editor to change the editorState onChange rather than on save/exit