### PR TITLE
Change blockType on multiple blocks

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -137,3 +137,17 @@ export function delayCall(fn, interval = 100) {
     timeout = window.setTimeout(() => fn.apply(window, args), interval);
   };
 }
+
+// credit: https://github.com/jpuri/draftjs-utils/blob/eca1508cf74c8b05ce7d3ab39ab28247cb254d5f/js/block.js#L13
+export function getSelectedBlocksMap(editorState) {
+  const selectionState = editorState.getSelection();
+  const contentState = editorState.getCurrentContent();
+  const startKey = selectionState.getStartKey();
+  const endKey = selectionState.getEndKey();
+  const blockMap = contentState.getBlockMap();
+  return blockMap
+    .toSeq()
+    .skipUntil((_, k) => k === startKey)
+    .takeUntil((_, k) => k === endKey)
+    .concat([[endKey, blockMap.get(endKey)]]);
+}

--- a/tests/components/toolbar_test.js
+++ b/tests/components/toolbar_test.js
@@ -84,6 +84,22 @@ describe("Toolbar Component", () => {
           depth: 0,
           inlineStyleRanges: [],
           entityRanges: []
+        },
+        {
+          key: "ag7qs",
+          text: "",
+          type: "atomic",
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: []
+        },
+        {
+          key: "ag8qs",
+          text: "Foo Bar",
+          type: "unstyled",
+          depth: 0,
+          inlineStyleRanges: [],
+          entityRanges: []
         }
       ]
     };
@@ -154,7 +170,7 @@ describe("Toolbar Component", () => {
       expect(toolbar.html()).not.toBeNull();
     });
 
-     it("renders as null when readOnly is set and shouldDisplayToolbarFn returns false", () => {
+    it("renders as null when readOnly is set and shouldDisplayToolbarFn returns false", () => {
       const wrapper = mount(
         <ToolbarWrapper
           readOnly
@@ -182,6 +198,15 @@ describe("Toolbar Component", () => {
       });
 
       it("toggles block style", () => {
+        replaceSelection(
+          {
+            anchorKey: "ag6qs",
+            anchorOffset: 0,
+            focusKey: "ag8qs",
+            focusOffset: 5
+          },
+          testContext.wrapper
+        );
         const items = testContext.wrapper.find(ToolbarItem);
         const titleItem = items.at(2);
         const button = titleItem.find("button");
@@ -189,13 +214,22 @@ describe("Toolbar Component", () => {
         button.simulate("click");
 
         const editorState = testContext.wrapper.state("editorState");
-        const selection = editorState.getSelection();
-        const current = editorState
+        const firstBlock = editorState
           .getCurrentContent()
-          .getBlockForKey(selection.getStartKey())
+          .getBlockForKey("ag6qs")
+          .getType();
+        const atomicBlock = editorState
+          .getCurrentContent()
+          .getBlockForKey("ag7qs")
+          .getType();
+        const lastBlock = editorState
+          .getCurrentContent()
+          .getBlockForKey("ag8qs")
           .getType();
 
-        expect(current).toEqual("header-two");
+        expect(firstBlock).toEqual("header-two");
+        expect(atomicBlock).toEqual("atomic");
+        expect(lastBlock).toEqual("header-two");
       });
 
       it("triggers custom action", () => {


### PR DESCRIPTION
In the case where there is a selection state that has a range of multiple blocks that surround a media/atomic block, using Draft.JS `RichUtils.toggleBlockType` will just return the current `editorState`. This is shown here in the Draft.JS source: https://github.com/facebook/draft-js/blob/c21a9f7f09fa737f27875dc5ca8264a0b1dc86c2/src/model/modifier/RichTextEditorUtil.js#L254

To get around this I changed the `toggleBlockType` method in the toolbar to get the Map of blocks in the selection range and update each block's type individually and skipping blocks that have `type=atomic`.